### PR TITLE
Add FormData::Multipart#boundary reader method

### DIFF
--- a/lib/http/form_data/multipart.rb
+++ b/lib/http/form_data/multipart.rb
@@ -12,6 +12,8 @@ module HTTP
     class Multipart
       include Readable
 
+      attr_reader :boundary
+
       # @param [#to_h, Hash] data form data key-value Hash
       def initialize(data)
         parts = Param.coerce FormData.ensure_hash data

--- a/lib/http/form_data/multipart.rb
+++ b/lib/http/form_data/multipart.rb
@@ -15,11 +15,19 @@ module HTTP
       attr_reader :boundary
 
       # @param [#to_h, Hash] data form data key-value Hash
-      def initialize(data)
+      def initialize(data, boundary: self.class.generate_boundary)
         parts = Param.coerce FormData.ensure_hash data
 
-        @boundary = ("-" * 21) << SecureRandom.hex(21)
+        @boundary = boundary.to_s.freeze
         @io = CompositeIO.new [*parts.flat_map { |part| [glue, part] }, tail]
+      end
+
+      # Generates a string suitable for using as a boundary in multipart form
+      # data.
+      #
+      # @return [String]
+      def self.generate_boundary
+        ("-" * 21) << SecureRandom.hex(21)
       end
 
       # Returns MIME type to be used for HTTP request `Content-Type` header.

--- a/spec/lib/http/form_data/multipart_spec.rb
+++ b/spec/lib/http/form_data/multipart_spec.rb
@@ -95,4 +95,13 @@ RSpec.describe HTTP::FormData::Multipart do
     subject { form_data.content_length }
     it { is_expected.to eq form_data.to_s.bytesize }
   end
+
+  describe "#boundary" do
+    subject { form_data.boundary }
+    it { is_expected.not_to be_empty }
+
+    it "is included in content type" do
+      expect(form_data.content_type).to end_with(form_data.boundary)
+    end
+  end
 end

--- a/spec/lib/http/form_data/multipart_spec.rb
+++ b/spec/lib/http/form_data/multipart_spec.rb
@@ -29,6 +29,23 @@ RSpec.describe HTTP::FormData::Multipart do
       ].join("")
     end
 
+    context "with user-defined boundary" do
+      let(:form_data) { HTTP::FormData::Multipart.new params, boundary: "my-boundary" }
+
+      it "uses the given boundary" do
+        expect(form_data.to_s).to eq [
+          "--my-boundary#{crlf}",
+          "#{disposition 'name' => 'foo'}#{crlf}",
+          "#{crlf}bar#{crlf}",
+          "--my-boundary#{crlf}",
+          "#{disposition 'name' => 'baz', 'filename' => file.filename}#{crlf}",
+          "Content-Type: #{file.content_type}#{crlf}",
+          "#{crlf}#{file}#{crlf}",
+          "--my-boundary--"
+        ].join("")
+      end
+    end
+
     context "with filename set to nil" do
       let(:part) { HTTP::FormData::Part.new("s", :content_type => "mime/type") }
       let(:form_data) { HTTP::FormData::Multipart.new(:foo => part) }
@@ -89,6 +106,14 @@ RSpec.describe HTTP::FormData::Multipart do
     let(:content_type) { %r{^multipart\/form-data; boundary=#{boundary}$} }
 
     it { is_expected.to match(content_type) }
+
+    context "with user-defined boundary" do
+      let(:form_data) { HTTP::FormData::Multipart.new params, boundary: "my-boundary" }
+
+      it "includes the given boundary" do
+        expect(form_data.content_type).to eq "multipart/form-data; boundary=my-boundary"
+      end
+    end
   end
 
   describe "#content_length" do
@@ -97,11 +122,22 @@ RSpec.describe HTTP::FormData::Multipart do
   end
 
   describe "#boundary" do
-    subject { form_data.boundary }
-    it { is_expected.not_to be_empty }
+    it "returns a new boundary" do
+      expect(form_data.boundary).to match(boundary)
+    end
 
-    it "is included in content type" do
-      expect(form_data.content_type).to end_with(form_data.boundary)
+    context "with user-defined boundary" do
+      let(:form_data) { HTTP::FormData::Multipart.new params, boundary: "my-boundary" }
+
+      it "returns the given boundary" do
+        expect(form_data.boundary).to eq "my-boundary"
+      end
+    end
+  end
+
+  describe ".generate_boundary" do
+    it "returns a string suitable as a multipart boundary" do
+      expect(form_data.class.generate_boundary).to match(boundary)
     end
   end
 end


### PR DESCRIPTION
I wanted to measure performance of the [`multipart-parser`](https://github.com/danabr/multipart-parser) gem, to compare it to the performance of Rack's multipart parser. I'm using `http-form_data` to generate test multipart data, and `multipart-parser` needs me to pass in the boundary. I can call `MultipartParser::Reader.extract_boundary_value` to extract the boundary from `FormData::Multipart#content_type` before parsing, but since the `FormData::Multipart` object already knows the boundary, I thought I could eliminate this extra step.