### PR TITLE
Make Urlencoded component into an IO object

### DIFF
--- a/lib/http/form_data/urlencoded.rb
+++ b/lib/http/form_data/urlencoded.rb
@@ -1,21 +1,20 @@
 # frozen_string_literal: true
 
+require "http/form_data/readable"
+
 require "uri"
+require "stringio"
 
 module HTTP
   module FormData
     # `application/x-www-form-urlencoded` form data.
     class Urlencoded
+      include Readable
+
       # @param [#to_h, Hash] data form data key-value Hash
       def initialize(data)
-        @data = FormData.ensure_hash data
-      end
-
-      # Returns content to be used for HTTP request body.
-      #
-      # @return [String]
-      def to_s
-        ::URI.encode_www_form @data
+        uri_encoded_data = ::URI.encode_www_form FormData.ensure_hash(data)
+        @io = StringIO.new(uri_encoded_data)
       end
 
       # Returns MIME type to be used for HTTP request `Content-Type` header.
@@ -29,9 +28,7 @@ module HTTP
       # `Content-Length` header.
       #
       # @return [Integer]
-      def content_length
-        to_s.bytesize
-      end
+      alias content_length size
     end
   end
 end

--- a/spec/lib/http/form_data/urlencoded_spec.rb
+++ b/spec/lib/http/form_data/urlencoded_spec.rb
@@ -29,4 +29,24 @@ RSpec.describe HTTP::FormData::Urlencoded do
       it { is_expected.to eq "foo%5Bbar%5D=%D1%82%D0%B5%D1%81%D1%82" }
     end
   end
+
+  describe "#size" do
+    it "returns bytesize of multipart data" do
+      expect(form_data.size).to eq form_data.to_s.bytesize
+    end
+  end
+
+  describe "#read" do
+    it "returns multipart data" do
+      expect(form_data.read).to eq form_data.to_s
+    end
+  end
+
+  describe "#rewind" do
+    it "rewinds the multipart data IO" do
+      form_data.read
+      form_data.rewind
+      expect(form_data.read).to eq form_data.to_s
+    end
+  end
 end


### PR DESCRIPTION
In https://github.com/httprb/form_data/pull/12 I forgot to also make the `Urlencoded` component into an IO object, so this PR fixes this inconsistency.

The reason why I need this is because I want to change the following HTTP.rb code:

```rb
def make_request_body(opts, headers)
  request_body =
    case
    # ...
    when opts.form
      form = HTTP::FormData.create opts.form
      headers[Headers::CONTENT_TYPE]   ||= form.content_type
      headers[Headers::CONTENT_LENGTH] ||= form.content_length
      form.to_s
    # ...
  # ...
end
```

into

```rb
def make_request_body(opts, headers)
  request_body =
    case
    # ...
    when opts.form
      form = HTTP::FormData.create opts.form
      headers[Headers::CONTENT_TYPE] ||= form.content_type
      form
    # ...
  # ...
end
```

So then I need the result of `FormData.create` to be an IO object, regardless of whether it's a `FormData::Multipart` or `FormData::Urlencoded`.