### PR TITLE
Add CRLF character to end of multipart body.

### DIFF
--- a/lib/http/form_data/multipart.rb
+++ b/lib/http/form_data/multipart.rb
@@ -52,7 +52,7 @@ module HTTP
 
       # @return [String]
       def tail
-        @tail ||= "--#{@boundary}--"
+        @tail ||= "--#{@boundary}--#{CRLF}"
       end
     end
   end

--- a/spec/lib/http/form_data/multipart_spec.rb
+++ b/spec/lib/http/form_data/multipart_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe HTTP::FormData::Multipart do
         "#{disposition 'name' => 'baz', 'filename' => file.filename}#{crlf}",
         "Content-Type: #{file.content_type}#{crlf}",
         "#{crlf}#{file}#{crlf}",
-        "--#{boundary_value}--"
+        "--#{boundary_value}--#{crlf}"
       ].join("")
     end
 
@@ -44,7 +44,7 @@ RSpec.describe HTTP::FormData::Multipart do
           "#{disposition 'name' => 'baz', 'filename' => file.filename}#{crlf}",
           "Content-Type: #{file.content_type}#{crlf}",
           "#{crlf}#{file}#{crlf}",
-          "--my-boundary--"
+          "--my-boundary--#{crlf}"
         ].join("")
       end
     end
@@ -61,7 +61,7 @@ RSpec.describe HTTP::FormData::Multipart do
           "#{disposition 'name' => 'foo'}#{crlf}",
           "Content-Type: #{part.content_type}#{crlf}",
           "#{crlf}s#{crlf}",
-          "--#{boundary_value}--"
+          "--#{boundary_value}--#{crlf}"
         ].join("")
       end
     end
@@ -77,7 +77,7 @@ RSpec.describe HTTP::FormData::Multipart do
           "--#{boundary_value}#{crlf}",
           "#{disposition 'name' => 'foo'}#{crlf}",
           "#{crlf}s#{crlf}",
-          "--#{boundary_value}--"
+          "--#{boundary_value}--#{crlf}"
         ].join("")
       end
     end


### PR DESCRIPTION
Per RFC 1521 this character is required at the end of multipart body.

Per RFC 2046 there is an optional CRLF character at the end of the multipart-body to delimit between the body and optional epilogue.

Some server implementations break if this character is not added, so adding it here as it complies with both RFCs.