### PR TITLE
Rewind content at the end of Readable#to_s

### DIFF
--- a/lib/http/form_data/readable.rb
+++ b/lib/http/form_data/readable.rb
@@ -9,7 +9,9 @@ module HTTP
       # @return [String]
       def to_s
         rewind
-        read
+        content = read
+        rewind
+        content
       end
 
       # Reads and returns part of IO content.

--- a/spec/lib/http/form_data/file_spec.rb
+++ b/spec/lib/http/form_data/file_spec.rb
@@ -2,10 +2,11 @@
 # coding: utf-8
 
 RSpec.describe HTTP::FormData::File do
-  let(:opts) { nil }
+  let(:opts)      { nil }
+  let(:form_file) { described_class.new(file, opts) }
 
   describe "#size" do
-    subject { described_class.new(file, opts).size }
+    subject { form_file.size }
 
     context "when file given as a String" do
       let(:file) { fixture("the-http-gem.info").to_s }
@@ -30,32 +31,56 @@ RSpec.describe HTTP::FormData::File do
   end
 
   describe "#to_s" do
-    subject { described_class.new(file, opts).to_s }
+    subject { form_file.to_s }
 
     context "when file given as a String" do
       let(:file) { fixture("the-http-gem.info").to_s }
       it { is_expected.to eq fixture("the-http-gem.info").read(:mode => "rb") }
+
+      it "rewinds content" do
+        content = form_file.read
+        expect(form_file.to_s).to eq content
+        expect(form_file.read).to eq content
+      end
     end
 
     context "when file given as a Pathname" do
       let(:file) { fixture("the-http-gem.info") }
       it { is_expected.to eq fixture("the-http-gem.info").read(:mode => "rb") }
+
+      it "rewinds content" do
+        content = form_file.read
+        expect(form_file.to_s).to eq content
+        expect(form_file.read).to eq content
+      end
     end
 
     context "when file given as File" do
       let(:file) { fixture("the-http-gem.info").open("rb") }
       after { file.close }
       it { is_expected.to eq fixture("the-http-gem.info").read(:mode => "rb") }
+
+      it "rewinds content" do
+        content = form_file.read
+        expect(form_file.to_s).to eq content
+        expect(form_file.read).to eq content
+      end
     end
 
     context "when file given as IO" do
       let(:file) { StringIO.new "привет мир!" }
       it { is_expected.to eq "привет мир!" }
+
+      it "rewinds content" do
+        content = form_file.read
+        expect(form_file.to_s).to eq content
+        expect(form_file.read).to eq content
+      end
     end
   end
 
   describe "#read" do
-    subject { described_class.new(file, opts).read }
+    subject { form_file.read }
 
     context "when file given as a String" do
       let(:file) { fixture("the-http-gem.info").to_s }
@@ -80,15 +105,13 @@ RSpec.describe HTTP::FormData::File do
   end
 
   describe "#rewind" do
-    subject { described_class.new(file, opts) }
-
     context "when file given as a String" do
       let(:file) { fixture("the-http-gem.info").to_s }
 
       it "rewinds the underlying IO object" do
-        content = subject.read
-        subject.rewind
-        expect(subject.read).to eq content
+        content = form_file.read
+        form_file.rewind
+        expect(form_file.read).to eq content
       end
     end
 
@@ -96,9 +119,9 @@ RSpec.describe HTTP::FormData::File do
       let(:file) { fixture("the-http-gem.info") }
 
       it "rewinds the underlying IO object" do
-        content = subject.read
-        subject.rewind
-        expect(subject.read).to eq content
+        content = form_file.read
+        form_file.rewind
+        expect(form_file.read).to eq content
       end
     end
 
@@ -107,9 +130,9 @@ RSpec.describe HTTP::FormData::File do
       after { file.close }
 
       it "rewinds the underlying IO object" do
-        content = subject.read
-        subject.rewind
-        expect(subject.read).to eq content
+        content = form_file.read
+        form_file.rewind
+        expect(form_file.read).to eq content
       end
     end
 
@@ -117,15 +140,15 @@ RSpec.describe HTTP::FormData::File do
       let(:file) { StringIO.new "привет мир!" }
 
       it "rewinds the underlying IO object" do
-        content = subject.read
-        subject.rewind
-        expect(subject.read).to eq content
+        content = form_file.read
+        form_file.rewind
+        expect(form_file.read).to eq content
       end
     end
   end
 
   describe "#filename" do
-    subject { described_class.new(file, opts).filename }
+    subject { form_file.filename }
 
     context "when file given as a String" do
       let(:file) { fixture("the-http-gem.info").to_s }
@@ -174,7 +197,8 @@ RSpec.describe HTTP::FormData::File do
   end
 
   describe "#content_type" do
-    subject { described_class.new(StringIO.new, opts).content_type }
+    let(:file) { StringIO.new }
+    subject    { form_file.content_type }
 
     it { is_expected.to eq "application/octet-stream" }
 

--- a/spec/lib/http/form_data/multipart_spec.rb
+++ b/spec/lib/http/form_data/multipart_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe HTTP::FormData::Multipart do
       ].join("")
     end
 
+    it "rewinds content" do
+      content = form_data.read
+      expect(form_data.to_s).to eq content
+      expect(form_data.read).to eq content
+    end
+
     context "with user-defined boundary" do
       subject(:form_data) do
         HTTP::FormData::Multipart.new params, :boundary => "my-boundary"

--- a/spec/lib/http/form_data/part_spec.rb
+++ b/spec/lib/http/form_data/part_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe HTTP::FormData::Part do
     context "when body given as String" do
       let(:body) { "привет мир!" }
       it { is_expected.to eq "привет мир!" }
+
+      it "rewinds content" do
+        content = part.read
+        expect(part.to_s).to eq content
+        expect(part.read).to eq content
+      end
     end
   end
 

--- a/spec/lib/http/form_data/urlencoded_spec.rb
+++ b/spec/lib/http/form_data/urlencoded_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe HTTP::FormData::Urlencoded do
       let(:data) { { "foo[bar]" => "тест" } }
       it { is_expected.to eq "foo%5Bbar%5D=%D1%82%D0%B5%D1%81%D1%82" }
     end
+
+    it "rewinds content" do
+      content = form_data.read
+      expect(form_data.to_s).to eq content
+      expect(form_data.read).to eq content
+    end
   end
 
   describe "#size" do


### PR DESCRIPTION
This allows calling `#read` after we've called `#to_s`.

This PR was motivated by https://github.com/httprb/http/issues/437#issuecomment-365591345, where in [httplog](https://github.com/trusche/httplog) it was required to `#rewind` the form body after calling `#to_s` on it ([source](https://github.com/trusche/httplog/pull/56/files#diff-59045ee971a3f4e401c5df47d6990b69R25)). I just thought that this was surprising behaviour, and that there is no reason why not rewind the content after calling `#to_s` on it.

Btw, I think it makes sense to still keep the `#rewind` before the `#read`, because httplog could one day decide they want to log the request data *after* the request has been made, at which point the form data objects would have been read. So then it would be nice to just be able to call `#to_s` and have it rewind the content automatically.