### PR TITLE
Ignore `.ruby-version` file by `git`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.bundle/
 /.yardoc
+/.ruby-version
 /Gemfile.lock
 /_yardoc/
 /coverage/


### PR DESCRIPTION
Common file for `rbenv`, `rvm`, RuboCop, etc.