### PR TITLE
Ruby 2.7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,14 @@ rvm:
   # Include JRuby first because it takes the longest
   - jruby-9.1.13.0
   - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
 
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.4
+  - rvm: 2.7
     env: SUITE="rubocop"
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: bundler
 before_install:
   - gem update --system
   - gem --version
-  - gem install bundler --no-rdoc --no-ri
+  - gem install bundler --no-document
   - bundle --version
 
 install: bundle install --without development doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,12 @@ env: JRUBY_OPTS="$JRUBY_OPTS --debug"
 rvm:
   # Include JRuby first because it takes the longest
   - jruby-9.1.13.0
-  - 2.2
-  - 2.3.4
-  - 2.4.1
+  - 2.4
 
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.4.1
+  - rvm: 2.4
     env: SUITE="rubocop"
 
 branches:

--- a/README.md
+++ b/README.md
@@ -58,11 +58,8 @@ form = HTTP::FormData.create({
 This library aims to support and is [tested against][ci] the following Ruby
 versions:
 
-* Ruby 2.1.x
-* Ruby 2.2.x
-* Ruby 2.3.x
-* Ruby 2.4.x
-* JRuby 9.1.x.x
+* Ruby 2.4+
+* JRuby 9.1+
 
 If something doesn't work on one of these versions, it's a bug.
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,11 @@ form = HTTP::FormData.create({
 This library aims to support and is [tested against][ci] the following Ruby
 versions:
 
-* Ruby 2.4+
-* JRuby 9.1+
+* Ruby 2.4.x
+* Ruby 2.5.x
+* Ruby 2.6.x
+* Ruby 2.7.x
+* JRuby 9.1.x.x
 
 If something doesn't work on one of these versions, it's a bug.
 

--- a/http-form_data.gemspec
+++ b/http-form_data.gemspec
@@ -22,6 +22,4 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin\/}).map { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)\/})
   spec.require_paths = ["lib"]
-
-  spec.add_development_dependency "bundler", "~> 1.7"
 end

--- a/spec/lib/http/form_data/multipart_spec.rb
+++ b/spec/lib/http/form_data/multipart_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe HTTP::FormData::Multipart do
 
     context "with filename set to nil" do
       let(:part) { HTTP::FormData::Part.new("s", :content_type => "mime/type") }
-      let(:form_data) { HTTP::FormData::Multipart.new(:foo => part) }
+      let(:form_data) { HTTP::FormData::Multipart.new({ :foo => part }) }
 
       it "doesn't include a filename" do
         boundary_value = form_data.content_type[/(#{boundary})$/, 1]
@@ -74,7 +74,7 @@ RSpec.describe HTTP::FormData::Multipart do
 
     context "with content type set to nil" do
       let(:part) { HTTP::FormData::Part.new("s") }
-      let(:form_data) { HTTP::FormData::Multipart.new(:foo => part) }
+      let(:form_data) { HTTP::FormData::Multipart.new({ :foo => part }) }
 
       it "doesn't include a filename" do
         boundary_value = form_data.content_type[/(#{boundary})$/, 1]

--- a/spec/lib/http/form_data/part_spec.rb
+++ b/spec/lib/http/form_data/part_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe HTTP::FormData::Part do
   let(:body)     { "" }
   let(:opts)     { {} }
-  subject(:part) { HTTP::FormData::Part.new(body, opts) }
+  subject(:part) { HTTP::FormData::Part.new(body, **opts) }
 
   describe "#size" do
     subject { part.size }


### PR DESCRIPTION
In Ruby 2.7 `Nil#to_s` now returns a frozen string, which caused `FrozenError` exceptions in `CompositeIO#read` when `outbuf` was `nil`. So, we update the code to handle this properly.

Ruby 2.7 also added deprecation warnings for the [upcoming separation of positional and keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) that is planned for Ruby 3.0. There were couple of specs that triggered the warning, so I updated the code to use the correct syntax.

I updated the Travis CI matrix to add 2.5, 2.6, and 2.7.