### PR TITLE
Add ability to pass encoder to HTTP::FormData::Urlencoded instance

### DIFF
--- a/lib/http/form_data.rb
+++ b/lib/http/form_data.rb
@@ -47,7 +47,7 @@ module HTTP
         if multipart?(data)
           Multipart.new(data)
         else
-          Urlencoded.new(data, encoder)
+          Urlencoded.new(data, encoder: encoder)
         end
       end
 

--- a/lib/http/form_data.rb
+++ b/lib/http/form_data.rb
@@ -41,11 +41,14 @@ module HTTP
       # @param [#to_h, Hash] data
       # @return [Multipart] if any of values is a {FormData::File}
       # @return [Urlencoded] otherwise
-      def create(data)
+      def create(data, encoder: nil)
         data  = ensure_hash data
-        klass = multipart?(data) ? Multipart : Urlencoded
 
-        klass.new data
+        if multipart?(data)
+          Multipart.new(data)
+        else
+          Urlencoded.new(data, encoder)
+        end
       end
 
       # Coerce `obj` to Hash.

--- a/lib/http/form_data.rb
+++ b/lib/http/form_data.rb
@@ -47,7 +47,7 @@ module HTTP
         if multipart?(data)
           Multipart.new(data)
         else
-          Urlencoded.new(data, encoder: encoder)
+          Urlencoded.new(data, :encoder => encoder)
         end
       end
 

--- a/lib/http/form_data.rb
+++ b/lib/http/form_data.rb
@@ -42,7 +42,7 @@ module HTTP
       # @return [Multipart] if any of values is a {FormData::File}
       # @return [Urlencoded] otherwise
       def create(data, encoder: nil)
-        data  = ensure_hash data
+        data = ensure_hash data
 
         if multipart?(data)
           Multipart.new(data)

--- a/lib/http/form_data/urlencoded.rb
+++ b/lib/http/form_data/urlencoded.rb
@@ -63,8 +63,9 @@ module HTTP
       end
 
       # @param [#to_h, Hash] data form data key-value Hash
-      def initialize(data)
-        @io = StringIO.new(self.class.encoder.call(FormData.ensure_hash(data)))
+      def initialize(data, encoder = nil)
+        encoder ||= self.class.encoder
+        @io = StringIO.new(encoder.call(FormData.ensure_hash(data)))
       end
 
       # Returns MIME type to be used for HTTP request `Content-Type` header.

--- a/lib/http/form_data/urlencoded.rb
+++ b/lib/http/form_data/urlencoded.rb
@@ -63,7 +63,7 @@ module HTTP
       end
 
       # @param [#to_h, Hash] data form data key-value Hash
-      def initialize(data, encoder = nil)
+      def initialize(data, encoder: nil)
         encoder ||= self.class.encoder
         @io = StringIO.new(encoder.call(FormData.ensure_hash(data)))
       end

--- a/spec/lib/http/form_data/urlencoded_spec.rb
+++ b/spec/lib/http/form_data/urlencoded_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe HTTP::FormData::Urlencoded do
   end
 
   context "with custom instance level encoder" do
-    let(:encoder) { Proc.new { |data| ::JSON.dump(data) } }
+    let(:encoder) { proc { |data| ::JSON.dump(data) } }
     subject(:form_data) { HTTP::FormData::Urlencoded.new(data, encoder) }
 
     it "uses encoder passed to initializer" do

--- a/spec/lib/http/form_data/urlencoded_spec.rb
+++ b/spec/lib/http/form_data/urlencoded_spec.rb
@@ -64,4 +64,13 @@ RSpec.describe HTTP::FormData::Urlencoded do
       expect(form_data.to_s).to eq('{"foo[bar]":"test"}')
     end
   end
+
+  context "with custom instance level encoder" do
+    let(:encoder) { Proc.new { |data| ::JSON.dump(data) } }
+    subject(:form_data) { HTTP::FormData::Urlencoded.new(data, encoder) }
+
+    it "uses encoder passed to initializer" do
+      expect(form_data.to_s).to eq('{"foo[bar]":"test"}')
+    end
+  end
 end

--- a/spec/lib/http/form_data/urlencoded_spec.rb
+++ b/spec/lib/http/form_data/urlencoded_spec.rb
@@ -67,7 +67,9 @@ RSpec.describe HTTP::FormData::Urlencoded do
 
   context "with custom instance level encoder" do
     let(:encoder) { proc { |data| ::JSON.dump(data) } }
-    subject(:form_data) { HTTP::FormData::Urlencoded.new(data, encoder: encoder) }
+    subject(:form_data) do
+      HTTP::FormData::Urlencoded.new(data, :encoder => encoder)
+    end
 
     it "uses encoder passed to initializer" do
       expect(form_data.to_s).to eq('{"foo[bar]":"test"}')

--- a/spec/lib/http/form_data/urlencoded_spec.rb
+++ b/spec/lib/http/form_data/urlencoded_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe HTTP::FormData::Urlencoded do
 
   context "with custom instance level encoder" do
     let(:encoder) { proc { |data| ::JSON.dump(data) } }
-    subject(:form_data) { HTTP::FormData::Urlencoded.new(data, encoder) }
+    subject(:form_data) { HTTP::FormData::Urlencoded.new(data, encoder: encoder) }
 
     it "uses encoder passed to initializer" do
       expect(form_data.to_s).to eq('{"foo[bar]":"test"}')


### PR DESCRIPTION
Since `encoder` is global and currently defined at the class level, it's difficult to customize on a per user-case basis. For example, there's an issue with the Twitter gem (https://github.com/sferik/twitter/issues/677), which depends on this gem, where the default encoding of asterisks does not work and Twitter will throw an error. The only way around this is to customize the encoding, **but** being forced to customize encoding at the class level makes things difficult since other gems could be using `http-form_data`. There's also no easy way to figure out if the Twitter gem is the one making the request in order to conditionally customize the encoding. In summary, defining an encoder at the global level makes it difficult to conditionally encode form data based on the current context.

Therefore, this PR adds the ability to pass in an encoder at the instance level when creating an `HTTP::FormData::Urlencoded` instance, which makes it easier to conditionally encode your form data.

Please let me know if I'm overlooking or missing anything here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/httprb/form_data/29)
<!-- Reviewable:end -->
