### PR TITLE
Add changelog to gemspec

### DIFF
--- a/http-form_data.gemspec
+++ b/http-form_data.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   > `multipart/form-data` types.
   DESC
 
+  spec.metadata["changelog_uri"] = "https://github.com/httprb/form_data/blob/master/CHANGES.md"
+
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin\/}).map { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)\/})


### PR DESCRIPTION
For a nice “Changelog” link in the https://rubygems.org/gems/http-form_data sidebar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/httprb/form_data/30)
<!-- Reviewable:end -->
